### PR TITLE
🐛 Fixed `::backdrop` attribute animation not to run in firefox.

### DIFF
--- a/packages/core/src/components/SwipeModal/SwipeModal.vue
+++ b/packages/core/src/components/SwipeModal/SwipeModal.vue
@@ -119,14 +119,18 @@ const handleOpenModal = () => {
 
 	modalRef.value?.style.setProperty("visibility", "visible");
 
-	modalRef.value.animate([
-		{ opacity: 0 },
-		{ opacity: 1 },
-	], {
-		duration: 200,
-		pseudoElement: "::backdrop",
-		easing: ANIMATION_EASING,
-	});
+	const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
+
+	if (!isFirefox) {
+		modalRef.value.animate([
+			{ opacity: 0 },
+			{ opacity: 1 },
+		], {
+			duration: 200,
+			pseudoElement: "::backdrop",
+			easing: ANIMATION_EASING,
+		});
+	}
 
 	modalRef.value.animate(
 		[
@@ -161,14 +165,18 @@ const handleCloseModal = () => {
 	if (!modalRef.value)
 		return;
 
-	modalRef.value.animate([
-		{ opacity: 1 },
-		{ opacity: 0 },
-	], {
-		duration: 300,
-		pseudoElement: "::backdrop",
-		easing: ANIMATION_EASING,
-	});
+	const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
+
+	if (!isFirefox) {
+		modalRef.value.animate([
+			{ opacity: 1 },
+			{ opacity: 0 },
+		], {
+			duration: 300,
+			pseudoElement: "::backdrop",
+			easing: ANIMATION_EASING,
+		});
+	}
 
 	modalRef.value.animate(
 		[


### PR DESCRIPTION
## What's changed
<!-- Briefly describe what you have done with this PR. -->
Fixed `::backdrop` attribute animation not to run in firefox.

## Issue
- #94 

## TODO
<!-- Please describe any issues that have not yet been resolved or that need to be addressed in the future. -->
- [ ] none

## Remark
<!-- Please describe any items that should be shared with reviewers -->